### PR TITLE
Add `session_id` to `session_with_datetime`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,14 +4,6 @@ on:
 jobs:
   make_github_release:
     uses: datajoint/.github/.github/workflows/make_github_release.yaml@main
-  pypi_release:
-    needs: make_github_release
-    uses: datajoint/.github/.github/workflows/pypi_release.yaml@main
-    secrets:
-      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
-      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-    with:
-      UPLOAD_URL: ${{needs.make_github_release.outputs.release_upload_url}}
   mkdocs_release:
     uses: datajoint/.github/.github/workflows/mkdocs_release.yaml@main
     permissions: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.0] - 2024-01-25
+
++ Add - `session_id` attribute to `Session` in `session_with_datetime.py`
++ Update - Remove PyPI release from GitHub Actions workflow
+
 ## [0.1.7] - 2023-11-30
 
-+ Allow null value for `session_datetime` in `session_with_id`
++ Update - Allow null value for `session_datetime` in `session_with_id`
 
 ## [0.1.6] - 2023-09-18
 
@@ -48,6 +53,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - GitHub Action release process
 + Add - `session` schema
 
+[0.2.0]: https://github.com/datajoint/element-session/releases/tag/0.2.0
 [0.1.7]: https://github.com/datajoint/element-session/releases/tag/0.1.7
 [0.1.6]: https://github.com/datajoint/element-session/releases/tag/0.1.6
 [0.1.5]: https://github.com/datajoint/element-session/releases/tag/0.1.5

--- a/element_session/session_with_datetime.py
+++ b/element_session/session_with_datetime.py
@@ -53,13 +53,16 @@ class Session(dj.Manual):
     """Central Session table
 
     Attributes:
-        Subject (foreign key): Key for Subject table
+        Subject (foreign key): Primary key from Subject table
         session_datetime (datetime): date and time of the session
+        session_id (int, optional): numerical session identifier
     """
 
     definition = """
     -> Subject
     session_datetime: datetime
+    ---
+    session_id=null: int
     """
 
     class Attribute(dj.Part):

--- a/element_session/version.py
+++ b/element_session/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.7"
+__version__ = "0.2.0"


### PR DESCRIPTION
This PR adds a secondary attribute to the `Session` table in the `session_with_datetime` module in this Element. This will allow users to add an optional numerical session identifier. 

This PR also removes PyPI release from the GitHub Actions workflow. 

Version and CHANGELOG have been incremented. 